### PR TITLE
bugfix: Add invisible scroll to fix menu screen overflow

### DIFF
--- a/src/front/public/js/templates/menuTemplate.js
+++ b/src/front/public/js/templates/menuTemplate.js
@@ -1,5 +1,6 @@
 export const menuTemplate = `
-     <ul class="flex flex-col items-center space-y-4 w-[40%]">
+<div class="w-full h-full flex flex-col items-center justify-center menu-container py-3">
+     <ul class="flex flex-col items-center space-y-4 w-[45%] max-h-[60vh] overflow-y-auto scrollable-menu px-4 pb-4">
         <li class="w-full"><button id="btn2p" class="threeD-button-set w-full">2 PLAYER</button></li>
         <li class="w-full"><button id="btnIa" class="threeD-button-set w-full">VS IA</button></li>
         <li class="w-full"><button id="btnOnline" class="threeD-button-set w-full">ONLINE</button></li>
@@ -8,5 +9,6 @@ export const menuTemplate = `
         <li class="w-full"><button id="btnBlockExplorer" class="threeD-button-set w-full">BLOCK EXPLORER</button></li>
         <li class="w-full"><button id="btnLogout" class="threeD-button-set w-full ">LOG OUT</button></li>
       </ul>
+</div>
 `;
 //# sourceMappingURL=menuTemplate.js.map

--- a/src/front/public/js/templates/menuTemplate.js.map
+++ b/src/front/public/js/templates/menuTemplate.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"menuTemplate.js","sourceRoot":"","sources":["../../../src/templates/menuTemplate.ts"],"names":[],"mappings":"AAAA,MAAM,CAAC,MAAM,YAAY,GAAG;;;;;;;;;;CAU3B,CAAC"}
+{"version":3,"file":"menuTemplate.js","sourceRoot":"","sources":["../../../src/templates/menuTemplate.ts"],"names":[],"mappings":"AAAA,MAAM,CAAC,MAAM,YAAY,GAAG;;;;;;;;;;;;CAY3B,CAAC"}

--- a/src/front/public/styles.css
+++ b/src/front/public/styles.css
@@ -293,6 +293,9 @@
   .mb-2 {
     margin-bottom: calc(var(--spacing) * 2);
   }
+  .mb-3 {
+    margin-bottom: calc(var(--spacing) * 3);
+  }
   .mb-4 {
     margin-bottom: calc(var(--spacing) * 4);
   }
@@ -371,6 +374,9 @@
   .h-screen {
     height: 100vh;
   }
+  .max-h-\[60vh\] {
+    max-height: 60vh;
+  }
   .max-h-\[80vh\] {
     max-height: 80vh;
   }
@@ -394,6 +400,9 @@
   }
   .w-\[40\%\] {
     width: 40%;
+  }
+  .w-\[45\%\] {
+    width: 45%;
   }
   .w-\[58\.4\%\] {
     width: 58.4%;
@@ -628,11 +637,20 @@
   .py-2 {
     padding-block: calc(var(--spacing) * 2);
   }
+  .py-3 {
+    padding-block: calc(var(--spacing) * 3);
+  }
   .py-4 {
     padding-block: calc(var(--spacing) * 4);
   }
   .pt-3 {
     padding-top: calc(var(--spacing) * 3);
+  }
+  .pb-4 {
+    padding-bottom: calc(var(--spacing) * 4);
+  }
+  .pb-5 {
+    padding-bottom: calc(var(--spacing) * 5);
   }
   .text-center {
     text-align: center;
@@ -933,6 +951,20 @@
   }
   .scrollbar-thin::-webkit-scrollbar-thumb:hover {
     background-color: #f97316;
+  }
+  .scrollable-menu::-webkit-scrollbar {
+    width: 0px;
+    background: transparent;
+  }
+  .scrollable-menu::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .scrollable-menu::-webkit-scrollbar-thumb {
+    background: transparent;
+  }
+  .scrollable-menu {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
   }
   .scroll-top::before {
     content: "▲";

--- a/src/front/src/style.css
+++ b/src/front/src/style.css
@@ -51,6 +51,25 @@
     background-color: #f97316;
   }
   
+  /* Hide scrollbar specifically for menu */
+  .scrollable-menu::-webkit-scrollbar {
+    width: 0px;
+    background: transparent;
+  }
+  
+  .scrollable-menu::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  
+  .scrollable-menu::-webkit-scrollbar-thumb {
+    background: transparent;
+  }
+  
+  .scrollable-menu {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE and Edge */
+  }
+  
   /* Scroll position indicators */
   .scroll-top::before {
     content: "▲";

--- a/src/front/src/templates/menuTemplate.ts
+++ b/src/front/src/templates/menuTemplate.ts
@@ -1,5 +1,6 @@
 export const menuTemplate = `
-     <ul class="flex flex-col items-center space-y-4 w-[40%]">
+<div class="w-full h-full flex flex-col items-center justify-center menu-container py-3">
+     <ul class="flex flex-col items-center space-y-4 w-[45%] max-h-[60vh] overflow-y-auto scrollable-menu px-4 pb-4">
         <li class="w-full"><button id="btn2p" class="threeD-button-set w-full">2 PLAYER</button></li>
         <li class="w-full"><button id="btnIa" class="threeD-button-set w-full">VS IA</button></li>
         <li class="w-full"><button id="btnOnline" class="threeD-button-set w-full">ONLINE</button></li>
@@ -8,4 +9,5 @@ export const menuTemplate = `
         <li class="w-full"><button id="btnBlockExplorer" class="threeD-button-set w-full">BLOCK EXPLORER</button></li>
         <li class="w-full"><button id="btnLogout" class="threeD-button-set w-full ">LOG OUT</button></li>
       </ul>
+</div>
 `;


### PR DESCRIPTION
## ft_transcendence PR message template and checklist.
Please fill in/check all the items below and PR!

## Brief one-line summary of the fix
Add invisible scrollbar to prevent menu overflow on small screens
		 
## Detailed description of the fix
- Fixed menu overflow issue where buttons were cut off on smaller screens
- Added vertical scroll functionality (overflow-y-auto) to menu container
- Made scrollbar completely invisible using CSS (.scrollable-menu class)
- Added proper padding (px-4 pb-4) to ensure button hover animations have sufficient space
- Maintained all existing functionality while improving responsive design

## Other questions
(Feel free to write any questions you have, things you noticed along the way, or anything else you want to share).
- The function logic seems to be too long, I wonder if there is a more efficient way to do it.(Example) 


## What's Next
- Write what's Next here

## CheckList
- [x] Check and follow the rules stated above
- [x] You have completed the necessary tests and verified that the functionality works properly.
