### PR TITLE
chore(elk): wait for Elasticsearch readiness and harden Logstash ES connections under low-resource constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ node_modules
 src/back/dist
 *.env
 *.env.*
-
+.env
+.env.*
 /docker/volumes
 log
 logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,10 +161,10 @@ services:
       test:
         [
           "CMD-SHELL",
-          "curl -k -u elastic:${ELASTIC_PASSWORD} https://localhost:9200/_cluster/health?wait_for_status=green&timeout=1s >/dev/null 2>&1",
+          "curl -k -u elastic:${ELASTIC_PASSWORD} https://elasticsearch:9200/_cluster/health?wait_for_status=green&timeout=1s >/dev/null 2>&1",
         ]
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 50
     restart: on-failure
     networks:
@@ -177,8 +177,8 @@ services:
       dockerfile: Dockerfile
     container_name: logstash
     environment:
-      - LOGSTASH_API_KEY=${LOGSTASH_API_KEY:-} #API key for Logstash
-      - LOGSTASH_MONITORING_API_KEY=${LOGSTASH_MONITORING_API_KEY:-} # API key for monitoring
+      - LOGSTASH_API_KEY #API key for Logstash
+      - LOGSTASH_MONITORING_API_KEY # API key for monitoring
       - ELASTICSEARCH_HOSTS=https://elasticsearch:9200
       - LS_JAVA_OPTS=-Xmx512m -Xms512m
       - LOGGING_ROOT_LEVEL=debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,7 @@ services:
         ]
       interval: 5s
       timeout: 10s
-      retries: 50
+      retries: 80
     restart: on-failure
     networks:
       elknet:
@@ -180,7 +180,7 @@ services:
       - LOGSTASH_API_KEY #API key for Logstash
       - LOGSTASH_MONITORING_API_KEY # API key for monitoring
       - ELASTICSEARCH_HOSTS=https://elasticsearch:9200
-      - LS_JAVA_OPTS=-Xmx512m -Xms512m
+      - LS_JAVA_OPTS=-Xmx1g -Xms1g
       - LOGGING_ROOT_LEVEL=debug
     env_file:
       - .env

--- a/docker/kibana/kibana-import/import-all.sh
+++ b/docker/kibana/kibana-import/import-all.sh
@@ -9,7 +9,7 @@ KIBANA_BASE="http://kibana:5601"
 ELASTIC_USER="elastic"
 ELASTIC_PASS="${ELASTIC_PASSWORD}"
 AUTH="-u ${ELASTIC_USER}:${ELASTIC_PASS}"
-PATTERN="ft_transcende-*"
+PATTERN="ft_transcende-logs-*"
 
 # ───────────────────────────────────────────────
 # 1) Wait for Kibana

--- a/docker/logstash/Dockerfile
+++ b/docker/logstash/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.elastic.co/logstash/logstash:8.17.2
 
 USER root
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends iproute2 lsof && \
+    apt-get install -y --no-install-recommends iproute2 lsof netcat-traditional && \
     rm -rf /var/lib/apt/lists/*
 
 COPY ./scripts/pull_chaine_generation.sh /usr/local/bin/pull_chaine_generation.sh

--- a/docker/logstash/Dockerfile
+++ b/docker/logstash/Dockerfile
@@ -11,7 +11,7 @@ RUN chmod +x /usr/local/bin/pull_chaine_generation.sh
 USER logstash
 COPY ./pipeline/ft_transcend.conf /usr/share/logstash/pipeline/
 COPY ./config/logstash.yml /usr/share/logstash/config/logstash.yml
-COPY ./config/pipelines.yml /usr/share/logstash/config/pipelines.yml
+#COPY ./config/pipelines.yml /usr/share/logstash/config/pipelines.yml
 # The above settings are additional when using multi-pipelines.
 
 EXPOSE 5044

--- a/docker/logstash/config/logstash.yml
+++ b/docker/logstash/config/logstash.yml
@@ -14,4 +14,5 @@ xpack.monitoring.enabled: true
 
 pipeline.buffer.type: heap
 
+path.config: /usr/share/logstash/pipeline/ft_transcend.conf
 path.logs: /var/log/logstash

--- a/docker/logstash/config/pipelines.yml
+++ b/docker/logstash/config/pipelines.yml
@@ -1,2 +1,1 @@
-- pipeline.id: main
-  path.config: "/usr/share/logstash/pipeline/ft_transcend.conf"
+# when serveral pipelines are used

--- a/docker/logstash/pipeline/ft_transcend.conf
+++ b/docker/logstash/pipeline/ft_transcend.conf
@@ -11,7 +11,6 @@ input {
     codec => json { target => "log" }
   }
 }
-
 filter {
 
   # use grok to extract timestamp, log level, and message text
@@ -65,15 +64,15 @@ output {
     ssl_certificate_authorities => "/usr/share/logstash/ca/ca.crt"  # CA for Elasticsearch TLS
     ssl_verification_mode     => "full"
     # ssl_certificate_verification => false  # for debugging only; not recommended
-
-    retry_initial_interval    => 5    # initial retry delay in seconds
-    retry_max_interval        => 60   # maximum retry delay in seconds
+   
+    retry_initial_interval    => 2    # initial retry delay in seconds
+    retry_max_interval        => 60 
     resurrect_delay           => 15000
     pool_max                  => 1000 # maximum connections in pool
     pool_max_per_route        => 100  # max connections per host
 
     manage_template           => true
-    template_name             => "ecs-logstash"
     template_overwrite        => true
+    template_name   => "ft_transcende-template"
   }
 }

--- a/docker/logstash/scripts/pull_chaine_generation.sh
+++ b/docker/logstash/scripts/pull_chaine_generation.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+for i in {1..300}; do
+  nc -z elasticsearch 9200 && break
+  sleep 1
+done
+
 TMP=/tmp/logstash-certs
 mkdir -p "$TMP"
 

--- a/scripts/api_token_generation.sh
+++ b/scripts/api_token_generation.sh
@@ -106,7 +106,7 @@ API_JSON=$(docker exec -i es sh -c '\
       "name": "logstash_api_key",
       "role_descriptors": {
         "logstash_writer": {
-          "cluster": ["monitor", "manage_index_templates"],
+          "cluster": ["monitor", "manage_index_templates", "manage_ilm"],
           "index": [
             {
               "names": ["ft_transcende-logs-*"],
@@ -117,6 +117,12 @@ API_JSON=$(docker exec -i es sh -c '\
       }
     }'\'' \
 ')
+
+if echo "$API_JSON" | jq -e 'has("error")' >/dev/null; then
+  echo "❌ Main Logstash API key Creating Failure:"
+  echo "$API_JSON" | jq .
+  exit 1
+fi
 
 ID=$(printf '%s' "$API_JSON" \
        | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
@@ -148,6 +154,12 @@ API_JSON=$(docker exec -i es sh -c '\
       }
     }'\'' \
 ')
+
+if echo "$API_JSON" | jq -e 'has("error")' >/dev/null; then
+  echo "❌ Monitoring API key Creating Failure:"
+  echo "$API_JSON" | jq .
+  exit 1
+fi
 
 ID=$(printf '%s' "$API_JSON" \
        | sed -n 's/.*"id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')


### PR DESCRIPTION
## ft_transcendence PR message template and checklist.
Please fill in/check all the items below and PR!


**Description:**
On lower-spec hardware, Logstash was racing Elasticsearch’s startup and exhausting limited resources—resulting in “connection refused” errors. This change ensures Logstash only begins once Elasticsearch is listening, and makes its ES output plugin more resilient to intermittent connectivity under constrained CPU/RAM.

**Changes:**

* **Entrypoint (`pull_chaine_generation.sh`):**

  * Added a FIFO loop (`for i in {1..300}`) with `nc -z elasticsearch 9200` to pause Logstash startup up to 5 minutes until ES is reachable.
* **Logstash pipeline config (`ft_transcend.conf`):**

  * Tuned ES output retry/backoff settings:

    * `retry_initial_interval` set to `2` s
    * `retry_max_interval` set to `60` s
    * `resurrect_delay` set to `15000` ms
  * These parameters force Logstash to persistently retry connections rather than fail fast.

**Impact:**

* Prevents premature Logstash failures when ES is slow to bind on resource-limited hosts.
* Improves overall stability of log ingestion during cluster startup or under transient load.


## Other questions
(Feel free to write any questions you have, things you noticed along the way, or anything else you want to share).
- The function logic seems to be too long, I wonder if there is a more efficient way to do it.(Example) 


## What's Next
- Write what's Next here

## CheckList
- [x] Check and follow the rules stated above
- [x] You have completed the necessary tests and verified that the functionality works properly.
