### PR TITLE
feat(ui): make arcade machine fullscreen and responsive

### DIFF
--- a/src/front/src/templates/arcadeTemplate.ts
+++ b/src/front/src/templates/arcadeTemplate.ts
@@ -1,10 +1,10 @@
 export const arcadeTemplate = `
-<div class="relative zoomable inline-block">
+<div class="relative zoomable flex justify-center items-center min-h-screen">
   <!-- Image in foreground, ignore pointer events -->
   <img
     src="./assets/arcademachine.png"
     alt="borne arcade"
-    class="relative z-10 filter brightness-100 hover:brightness-75 transition pointer-events-none"
+    class="relative z-10 h-screen w-auto filter brightness-100 hover:brightness-75 transition pointer-events-none"
   />
 
   <!-- Interactive div under the image -->


### PR DESCRIPTION
## ft_transcendence PR message template and checklist.
Please fill in/check all the items below and PR!

## Brief one-line summary of the fix
feat(ui): make arcade machine responsive with 100vh height

## Detailed description of the fix
- Change container from inline-block to flexbox with centering
- Set arcade machine image to always use full viewport height (h-screen)
- Maintain aspect ratio with w-auto
- Center arcade machine on screen for better responsive design

## Other questions
(Feel free to write any questions you have, things you noticed along the way, or anything else you want to share).
- The function logic seems to be too long, I wonder if there is a more efficient way to do it.(Example) 


## What's Next
- Write what's Next here

## CheckList
- [x] Check and follow the rules stated above
- [x] You have completed the necessary tests and verified that the functionality works properly.
